### PR TITLE
fix(auth): Ensured .env config is loaded before accessing  in FacebookAuthController.

### DIFF
--- a/src/Controllers/FacebookAuthController.php
+++ b/src/Controllers/FacebookAuthController.php
@@ -5,6 +5,7 @@ namespace Controllers;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Helpers\Helpers;
 use Symfony\Component\Yaml\Yaml;
 
 class FacebookAuthController
@@ -15,6 +16,9 @@ class FacebookAuthController
 
     public function __construct()
     {
+        // Forzamos la carga de la configuración para asegurar que $_ENV esté poblado
+        Helpers::getProjectConfig();
+        
         // Se cargan desde el .env (basado en la estructura del proyecto)
         $this->clientId = $_ENV['FACEBOOK_APP_ID'] ?? '';
         $this->clientSecret = $_ENV['FACEBOOK_APP_SECRET'] ?? '';


### PR DESCRIPTION
Added explicit call to Helpers::getProjectConfig() in constructor to ensure that environment variables from .env (including those from ENV_FILE overrides) are properly loaded into  before they are consumed by the auth controller, fixing unauthorized errors in Docker deployments.
