### PR TITLE
fix(auth): Improved HTTPS detection for Facebook Redirect URIs.

### DIFF
--- a/src/Controllers/FacebookAuthController.php
+++ b/src/Controllers/FacebookAuthController.php
@@ -22,7 +22,20 @@ class FacebookAuthController
         // Se cargan desde el .env (basado en la estructura del proyecto)
         $this->clientId = $_ENV['FACEBOOK_APP_ID'] ?? '';
         $this->clientSecret = $_ENV['FACEBOOK_APP_SECRET'] ?? '';
-        $this->redirectUri = $_ENV['FACEBOOK_REDIRECT_URI'] ?? (isset($_SERVER['HTTPS']) ? 'https' : 'http') . "://$_SERVER[HTTP_HOST]/fb-callback";
+        
+        // Detección mejorada de Protocolo (HTTPS detrás de Proxies como Nginx en Docker)
+        $isHttps = (
+            (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] === 'on' || $_SERVER['HTTPS'] === 1)) ||
+            (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https')
+        );
+        $protocol = $isHttps ? 'https' : 'http';
+        
+        // Forzado automático: Si no estamos en localhost, casi con seguridad Facebook exige HTTPS
+        if (isset($_SERVER['HTTP_HOST']) && !str_contains($_SERVER['HTTP_HOST'], 'localhost') && !str_contains($_SERVER['HTTP_HOST'], '127.0.0.1')) {
+            $protocol = 'https';
+        }
+
+        $this->redirectUri = $_ENV['FACEBOOK_REDIRECT_URI'] ?? "$protocol://$_SERVER[HTTP_HOST]/fb-callback";
     }
 
     /**


### PR DESCRIPTION
Updated FacebookAuthController to check for X-Forwarded-Proto headers (common in Docker/Nginx setups) and force HTTPS in non-localhost environments to ensure compliance with Facebook's mandatory secure connection policy.
